### PR TITLE
package manifest, variables for length and command path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,0 @@
-build
-ipkbuild
-*.ipk

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build
+ipkbuild
+*.ipk

--- a/command.sh
+++ b/command.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "would launch something"

--- a/main.cpp
+++ b/main.cpp
@@ -11,6 +11,9 @@
 
 using namespace std;
 
+const char * commandFile = "/opt/etc/button-capture/command.sh";
+long millis = 1000;
+
 //Keeping track of presses.
 struct PressRecord {
     bool pressed = false;
@@ -32,7 +35,7 @@ int main()
     // Open the button device.
     ifstream eventsfile;
     eventsfile.open("/dev/input/event2", ios::in);
-    if(eventsfile.is_open()) {
+    if (eventsfile.is_open()) {
         cout << "File open for reading." << endl;
     }
     else {
@@ -44,17 +47,17 @@ int main()
     input_event ie;
     streamsize sie = static_cast<streamsize>(sizeof(struct input_event));
 
-    while(eventsfile.read((char*)&ie, sie)) {
+    while (eventsfile.read((char *)&ie, sie)) {
 
         // Read for non-zero event codes.
-        if(ie.code != 0) {
+        if (ie.code != 0) {
 
             // Toggle the button state.
             map[ie.code].pressed = !map[ie.code].pressed;
 
             // On press
-            if(map[ie.code].pressed) {
-                gettimeofday(&map[ie.code].pressTime,NULL);
+            if (map[ie.code].pressed) {
+                gettimeofday(&map[ie.code].pressTime, NULL);
                 cout << map[ie.code].name << " " << "DOWN" << endl;
             }
 
@@ -64,21 +67,21 @@ int main()
                 gettimeofday(&ctime,NULL);
 
                 // Calculate length of hold
-                long usecs = ((ctime.tv_sec   -  map[ie.code].pressTime.tv_sec  )*1000000L
+                long usecs = ((ctime.tv_sec   -  map[ie.code].pressTime.tv_sec  ) * 1000000L
                               +ctime.tv_usec) -  map[ie.code].pressTime.tv_usec;
 
                 // Print out press information
                 cout << map[ie.code].name << " " << "UP (" << usecs << " microseconds)" << endl;
 
                 // Check if MIDDLE was held for > 1 second
-                if(map[ie.code].name == "Middle" && usecs > 1000000L) {
+                if (map[ie.code].name == "Middle" && usecs >= millis * 1000) {
                     ifstream termfile;
-                    // Then execute the contents of /etc/draft/.terminate
-                    termfile.open("/etc/draft/.terminate", ios::in);
-                    if(termfile.is_open()) {
+                    // Then execute the contents of commandFile
+                    termfile.open(commandFile, ios::in);
+                    if (termfile.is_open()) {
                         cout << "Termfile exists and can be read." << endl;
                         termfile.close();
-                        system("/bin/bash /etc/draft/.terminate");
+                        system("/bin/bash " + *commandFile);
                     }
                     else {
                         cout << "Termfile couldn't be read." << endl;

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,13 @@
+info:
+  package-name: rm-button-capture
+  version: 1.0
+  architecture: armv7-3.2
+  maintainer: Pierre-Alexis Ciavaldini <pierre-alexis@ciavaldini.fr>
+  description: A simple program to captire gpio button input on the reMarkable
+data:
+  opt:
+    bin:
+      button-capture: build/button-capture
+    etc:
+      button-capture:
+        command.sh: command.sh

--- a/manifest.yml
+++ b/manifest.yml
@@ -10,4 +10,4 @@ data:
       button-capture: build/button-capture
     etc:
       button-capture:
-        command.sh: command.sh
+        command.sh: src/command.sh


### PR DESCRIPTION
- inserted package manifest
- added `command.sh` to store a default command
- declared variables for the the command file and press length
- (added a few spaces)